### PR TITLE
[cinder-csi-plugin] Modifying InitDelay and DetachSteps values for disk attach detach operations

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -30,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
-
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -40,12 +38,12 @@ const (
 	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
-	diskAttachInitDelay      = 1 * time.Second
+	diskAttachInitDelay      = 6 * time.Second
 	diskAttachFactor         = 1.2
 	diskAttachSteps          = 15
-	diskDetachInitDelay      = 1 * time.Second
+	diskDetachInitDelay      = 6 * time.Second
 	diskDetachFactor         = 1.2
-	diskDetachSteps          = 13
+	diskDetachSteps          = 15
 	volumeDescription        = "Created by OpenStack Cinder CSI driver"
 )
 


### PR DESCRIPTION
Increasing the diskAttachInitDelay and diskDetachInitDelay to 6 seconds and diskDetachSteps to 15. Current interval likely too short for the attach/detach process to go through.