### PR TITLE
Klog import statement redefined

### DIFF
--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cloud-provider-openstack/pkg/metrics"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
+	klog "k8s.io/klog/v2"
 )
 
 const (


### PR DESCRIPTION
To resolve
```
# make cinder-csi-plugin
CGO_ENABLED=0 GOOS=linux GOARCH= GOPROXY=https://proxy.golang.org,direct go build \
        -trimpath \
        -ldflags "-w -s -X 'k8s.io/component-base/version.gitVersion=v1.27.0-13-g7f6f93d5-dirty'" \
        -o cinder-csi-plugin \
        cmd/cinder-csi-plugin/main.go
# k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack
pkg/csi/cinder/openstack/openstack_volumes.go:184:4: undefined: klog
pkg/csi/cinder/openstack/openstack_volumes.go:276:3: undefined: klog
pkg/csi/cinder/openstack/openstack_volumes.go:292:4: undefined: klog
make: *** [Makefile:75: cinder-csi-plugin] Error 1
```