### PR TITLE
Removed harcoded creds for CSI Cinder nodeplugin

### DIFF
--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -32,8 +32,7 @@ import (
 )
 
 var (
-	endpoint string
-	// regionName   string
+	endpoint     string
 	nodeID       string
 	cloudconfig  []string
 	cluster      string
@@ -83,13 +82,11 @@ func main() {
 	if err := cmd.MarkPersistentFlagRequired("endpoint"); err != nil {
 		klog.Fatalf("Unable to mark flag endpoint to be required: %v", err)
 	}
-
-	// cmd.PersistentFlags().StringVar(&regionName, "region", "", "Region name")
 	cmd.PersistentFlags().StringSliceVar(&cloudconfig, "cloud-config", nil, "CSI driver cloud config. This option can be given multiple times")
-	// Make it optional will use internal hardcoded config if not provided
-	// if err := cmd.MarkPersistentFlagRequired("cloud-config"); err != nil {
-	// 	klog.Fatalf("Unable to mark flag cloud-config to be required: %v", err)
-	// }
+	// Making it required as we are expecting cloud-config to be available via flag
+	if err := cmd.MarkPersistentFlagRequired("cloud-config"); err != nil {
+		klog.Fatalf("Unable to mark flag cloud-config to be required: %v", err)
+	}
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")

--- a/cmd/cinder-csi-plugin/main.go
+++ b/cmd/cinder-csi-plugin/main.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	endpoint     string
-	regionName   string
+	endpoint string
+	// regionName   string
 	nodeID       string
 	cloudconfig  []string
 	cluster      string
@@ -84,7 +84,7 @@ func main() {
 		klog.Fatalf("Unable to mark flag endpoint to be required: %v", err)
 	}
 
-	cmd.PersistentFlags().StringVar(&regionName, "region", "", "Region name")
+	// cmd.PersistentFlags().StringVar(&regionName, "region", "", "Region name")
 	cmd.PersistentFlags().StringSliceVar(&cloudconfig, "cloud-config", nil, "CSI driver cloud config. This option can be given multiple times")
 	// Make it optional will use internal hardcoded config if not provided
 	// if err := cmd.MarkPersistentFlagRequired("cloud-config"); err != nil {
@@ -103,7 +103,7 @@ func handle() {
 
 	// Initialize cloud
 	d := cinder.NewDriver(endpoint, cluster)
-	openstack.InitOpenStackProvider(cloudconfig, regionName, httpEndpoint)
+	openstack.InitOpenStackProvider(cloudconfig, httpEndpoint)
 	cloud, err := openstack.GetOpenStackProvider()
 	if err != nil {
 		klog.Warningf("Failed to GetOpenStackProvider: %v", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -138,7 +138,6 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 			authOpts.Username, authOpts.APIKey)
 	}
 
-	fmt.Printf("authOpts RAJENDRA line no 141 - %+v \n", authOpts)
 	opts := clientconfig.ClientOpts{
 		// this is needed to disable the clientconfig.AuthOptions func env detection
 		EnvPrefix: "_",
@@ -162,7 +161,6 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 			ApplicationCredentialSecret: authOpts.ApplicationCredentialSecret,
 		},
 	}
-	fmt.Printf("opts RAJENDRA line no 165 - %+v \n", opts.AuthInfo)
 
 	ao, err := clientconfig.AuthOptions(&opts)
 	if err != nil {
@@ -172,8 +170,6 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 
 	// Persistent service, so we need to be able to renew tokens.
 	ao.AllowReauth = true
-	ao.DomainName = authOpts.DomainName
-	fmt.Printf("RAJENDRA ao line no 175 - %+v \n", ao)
 	return *ao
 }
 
@@ -318,10 +314,7 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 
 		return provider, err
 	}
-	fmt.Printf("cfg RAJENDRA Line 317 - %+v \n", cfg)
 	opts := cfg.ToAuthOptions()
-	fmt.Printf("opts RAJENDRA line 319 - %+v \n", opts.DomainName)
 	err = openstack.Authenticate(provider, opts)
-	fmt.Printf("error  RAJENDRA line 323 - %+v \n", err)
 	return provider, err
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -138,6 +138,7 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 			authOpts.Username, authOpts.APIKey)
 	}
 
+	fmt.Printf("authOpts RAJENDRA line no 141 - %+v \n", authOpts)
 	opts := clientconfig.ClientOpts{
 		// this is needed to disable the clientconfig.AuthOptions func env detection
 		EnvPrefix: "_",
@@ -161,6 +162,7 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 			ApplicationCredentialSecret: authOpts.ApplicationCredentialSecret,
 		},
 	}
+	fmt.Printf("opts RAJENDRA line no 165 - %+v \n", opts.AuthInfo)
 
 	ao, err := clientconfig.AuthOptions(&opts)
 	if err != nil {
@@ -170,6 +172,8 @@ func (authOpts AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
 
 	// Persistent service, so we need to be able to renew tokens.
 	ao.AllowReauth = true
+	ao.DomainName = authOpts.DomainName
+	fmt.Printf("RAJENDRA ao line no 175 - %+v \n", ao)
 	return *ao
 }
 
@@ -314,9 +318,10 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 
 		return provider, err
 	}
-
+	fmt.Printf("cfg RAJENDRA Line 317 - %+v \n", cfg)
 	opts := cfg.ToAuthOptions()
+	fmt.Printf("opts RAJENDRA line 319 - %+v \n", opts.DomainName)
 	err = openstack.Authenticate(provider, opts)
-
+	fmt.Printf("error  RAJENDRA line 323 - %+v \n", err)
 	return provider, err
 }

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -149,13 +149,6 @@ func InitOpenStackProvider(cfgFiles []string, httpEndpoint string) {
 			klog.Infof("metrics available in %q", httpEndpoint)
 		}()
 	}
-	// if len(cfgFiles) == 0 {
-	// 	klog.Infof("Using internal cloud config file: %s", cfgFiles)
-	// 	if err := createCfgFile(configFiles[0], regionName); err != nil {
-	// 		klog.Fatalf("Failed to create cloud config file: %v", err)
-	// 	}
-	// 	return
-	// }
 	klog.Infof("Using provided cloud config files: %s", cfgFiles)
 	configFiles = cfgFiles
 	klog.V(2).Infof("InitOpenStackProvider configFiles: %s", configFiles)
@@ -170,21 +163,17 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 		return nil, err
 	}
 	logcfg(cfg)
-	fmt.Printf("cfg RAJENDRA - %+v \n", cfg)
 	provider, err := client.NewOpenStackClient(&cfg.Global, "cinder-csi-plugin", userAgentData...)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("provider RAJENDRA - %+v \n", provider)
 	epOpts := gophercloud.EndpointOpts{
 		Region:       cfg.Global.Region,
 		Availability: cfg.Global.EndpointType,
 	}
-	fmt.Printf("epOpts RAJENDRA - %+v \n", epOpts)
 	// Init Nova ServiceClient
 	computeclient, err := openstack.NewComputeV2(provider, epOpts)
 	if err != nil {
-		fmt.Printf("Error in create compute v2 client RAJENDRA - %+v \n", err)
 		return nil, err
 	}
 
@@ -201,14 +190,11 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 		blockstorageclient.Endpoint = endpoint
 		klog.Infof("Obtained blockstorage client v1 for OSPC cloud", "blockstorageclient", blockstorageclient)
 	} else {
-		fmt.Printf("ELSE RAJENDRA")
 		blockstorageclient, err = openstack.NewBlockStorageV3(provider, epOpts)
 		if err != nil {
-			fmt.Printf("Error in create v3 block client RAJENDRA - %+v \n", err)
 			return nil, err
 		}
 		klog.Infof("Obtained blockstorage client v3", "blockstorageclient", blockstorageclient)
-		fmt.Printf("Obtained blockstorage client v3", "blockstorageclient", blockstorageclient)
 	}
 
 	// if no search order given, use default
@@ -246,45 +232,3 @@ func GetOpenStackProvider() (IOpenStack, error) {
 func (os *OpenStack) GetMetadataOpts() metadata.Opts {
 	return os.metadataOpts
 }
-
-// func createCfgFile(filepath string, regionName string) error {
-// 	var data string
-// 	if util.GetCloudTypeFromEnv() == util.CloudTypeOSPC {
-// 		klog.Infof("Creating cloud conf for OSPC cloud")
-
-// 		data = fmt.Sprintf(`[Global]
-// auth-url=<redacted>
-// username=<redacted>
-// api-key=<redacted>
-// region="%s"
-// tenant-id=<redacted>
-
-// [LoadBalancer]
-
-// [BlockStorage]
-// bs-version=v2
-
-// [Networking]
-// internal-network-name=private
-// public-network-name=public`, regionName)
-// 	} else {
-// 		data = fmt.Sprintf(`[Global]
-// auth-url=https://keystone.api.sjc3.rackspacecloud.com/v3/
-// username=spot.rackspace@rackspace.com
-// password=lalaparabolala
-// region="%s"
-// tenant-id=521b087a774d11efb8640242ac120002
-// domain-name=rackspace_cloud_domain
-
-// [LoadBalancer]
-
-// [BlockStorage]
-// bs-version=v2
-
-// [Networking]
-// internal-network-name=private
-// public-network-name=public`, regionName)
-// 	}
-
-// 	return os.WriteFile(filepath, []byte(data), 0644)
-// }

--- a/pkg/csi/cinder/openstack/openstack.go
+++ b/pkg/csi/cinder/openstack/openstack.go
@@ -167,10 +167,12 @@ func CreateOpenStackProvider() (IOpenStack, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	epOpts := gophercloud.EndpointOpts{
 		Region:       cfg.Global.Region,
 		Availability: cfg.Global.EndpointType,
 	}
+
 	// Init Nova ServiceClient
 	computeclient, err := openstack.NewComputeV2(provider, epOpts)
 	if err != nil {


### PR DESCRIPTION
This PR has removed all the hard-coded credentials for CSI Cinder nodeplugin.
With this change, CSI Cinder nodeplugin will be able to use Claymore config which is passed to the daemonset running in Cloudspace via Kubernetes secret.

This change removes all security concerns around credentials and makes overall system much safer and cleaner. 