### PR TITLE
modified entrypoint.sh to add cluster name as metadata

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -15,10 +15,12 @@ if [[ -z "${REGION}" ]]; then
   /bin/cinder-csi-plugin \
     --endpoint="$(echo "${CSI_ENDPOINT}" | xargs)" \
     --cloud-config="$(echo "${CLOUD_CONFIG}" | xargs)" \
+    --cluster="$(echo "${CLUSTER_NAME}" | xargs)" \
     --v=5
 else
   /bin/cinder-csi-plugin \
     --endpoint="$(echo "${CSI_ENDPOINT}" | xargs)" \
     --region="$(echo "${REGION}" | xargs)" \
+    --cluster="$(echo "${CLUSTER_NAME}" | xargs)" \
     --v=5
 fi


### PR DESCRIPTION
This PR updates the executable to include the cluster name, which is then added as metadata. It will be helps in querying PVs based on the metadata.

```shell
    "multiattach": false,
    "metadata": {
      "cinder.csi.openstack.org/cluster": "c-5fd44d7f",
      <SNIPPED>
    },
```