### PR TITLE
changes to force ListVolume to use csi-proxy service

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -196,7 +197,8 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		return nil, status.Error(codes.InvalidArgument, "[ControllerPublishVolume] Volume capability must be provided")
 	}
 
-	_, err := cs.Cloud.GetVolume(volumeID)
+	//_, err := cs.Cloud.GetVolume(volumeID)
+	_, err := fetchVolumeByIDHTTP(volumeID)
 	if err != nil {
 		if cpoerrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] Volume %s not found", volumeID)
@@ -520,6 +522,170 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 	return volumeList, nextToken, nil
 }
 
+func fetchVolumeByIDHTTP(volumeID string) (*volumes.Volume, error) {
+	fmt.Printf("fetchVolumeByIDHTTP....")
+	// Generate a unique request ID
+	requestID := generateRequestID()
+
+	// Get configuration from environment variables
+	baseURL := os.Getenv("VOLUMES_API_URL")
+	region := os.Getenv("VOLUMES_API_REGION")
+	clusterName := os.Getenv("CLUSTER_NAME")
+
+	if baseURL == "" || region == "" {
+		return nil, fmt.Errorf("required environment variables VOLUMES_API_URL and VOLUMES_API_REGION not set")
+	}
+
+	if clusterName == "" {
+		// Use a default cluster name if not provided
+		clusterName = "unknown-cluster"
+		klog.V(4).Infof("CLUSTER_NAME environment variable not set, using default: %s", clusterName)
+	}
+
+	klog.V(4).Infof("Fetching volume by ID from baseURL: %s, region: %s, requestID: %s, cluster: %s, volumeID: %s",
+		baseURL, region, requestID, clusterName, volumeID)
+
+	// Construct the URL for the specific volume
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing base URL: %w", err)
+	}
+
+	// Add the volume ID to the path
+	u.Path = path.Join(u.Path, volumeID)
+
+	// Add the query parameters
+	query := u.Query()
+	query.Set("region", region)
+	u.RawQuery = query.Encode()
+
+	klog.V(5).Infof("Fetching volume from URL: %s", u.String())
+
+	// Create a new HTTP client with timeout
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	// Create a new request
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", requestID)
+	req.Header.Set("X-Cluster-Name", clusterName)
+
+	// Add authorization header
+	authToken := os.Getenv("VOLUMES_API_TOKEN")
+	if authToken == "" {
+		// If not set in environment, return an error
+		return nil, fmt.Errorf("required environment variable VOLUMES_API_TOKEN not set")
+	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	klog.V(5).Infof("Added Authorization header with Bearer token and request tracking headers")
+
+	// Make the HTTP request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, cpoerrors.ErrNotFound
+		}
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading error response body: %w, status code: %d", err, resp.StatusCode)
+		}
+		bodyString := string(bodyBytes)
+		return nil, fmt.Errorf("server returned error: %s, status code: %d, response body: %s", resp.Status, resp.StatusCode, bodyString)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	// Define a custom volume struct to handle string fields that need conversion
+	type CustomAttachment struct {
+		ServerID     string `json:"server_id"`
+		AttachmentID string `json:"attachment_id"`
+		HostName     string `json:"host_name"`
+		VolumeID     string `json:"volume_id"`
+		Device       string `json:"device"`
+		ID           string `json:"id"`
+	}
+
+	type CustomVolume struct {
+		ID                 string             `json:"id"`
+		DisplayName        string             `json:"display_name"`
+		Status             string             `json:"status"`
+		Size               int                `json:"size"`
+		Metadata           map[string]string  `json:"metadata"`
+		AvailabilityZone   string             `json:"availability_zone"`
+		DisplayDescription string             `json:"display_description"`
+		VolumeType         string             `json:"volume_type"`
+		CreatedAt          string             `json:"created_at"`
+		Bootable           string             `json:"bootable"`
+		Encrypted          bool               `json:"encrypted"`
+		Multiattach        string             `json:"multiattach"`
+		Attachments        []CustomAttachment `json:"attachments"`
+	}
+
+	// Unmarshal the JSON response
+	var volumeResponse struct {
+		Volume CustomVolume `json:"volume"`
+	}
+
+	err = json.Unmarshal(body, &volumeResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON: %w, body: %s", err, string(body))
+	}
+
+	cv := volumeResponse.Volume
+
+	// Convert string fields to appropriate types
+	multiattach := cv.Multiattach == "true"
+
+	// Convert attachments
+	attachments := make([]volumes.Attachment, 0, len(cv.Attachments))
+	for _, ca := range cv.Attachments {
+		attachments = append(attachments, volumes.Attachment{
+			ServerID:     ca.ServerID,
+			AttachmentID: ca.AttachmentID,
+			HostName:     ca.HostName,
+			VolumeID:     ca.VolumeID,
+			Device:       ca.Device,
+			ID:           ca.ID,
+		})
+	}
+
+	// Create a volumes.Volume object
+	vol := &volumes.Volume{
+		ID:               cv.ID,
+		Name:             cv.DisplayName,
+		Status:           cv.Status,
+		Size:             cv.Size,
+		AvailabilityZone: cv.AvailabilityZone,
+		Description:      cv.DisplayDescription,
+		VolumeType:       cv.VolumeType,
+		Metadata:         cv.Metadata,
+		Bootable:         cv.Bootable,
+		Encrypted:        cv.Encrypted,
+		Multiattach:      multiattach,
+		Attachments:      attachments,
+	}
+
+	klog.V(4).Infof("Successfully fetched volume with ID: %s", volumeID)
+	return vol, nil
+}
+
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	klog.V(4).Infof("CreateSnapshot: called with args %+v", protosanitizer.StripSecrets(*req))
 
@@ -726,7 +892,9 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		return nil, status.Error(codes.InvalidArgument, "ValidateVolumeCapabilities Volume ID must be provided")
 	}
 
-	_, err := cs.Cloud.GetVolume(volumeID)
+	// _, err := cs.Cloud.GetVolume(volumeID)
+	// Use HTTP implementation instead of cs.Cloud.GetVolume
+	_, err := fetchVolumeByIDHTTP(volumeID)
 	if err != nil {
 		if cpoerrors.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, fmt.Sprintf("ValidateVolumeCapabiltites Volume %s not found", volumeID))
@@ -767,7 +935,8 @@ func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
 	}
 
-	volume, err := cs.Cloud.GetVolume(volumeID)
+	//volume, err := cs.Cloud.GetVolume(volumeID)
+	volume, err := fetchVolumeByIDHTTP(volumeID)
 	if err != nil {
 		if cpoerrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "Volume %s not found", volumeID)

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -371,14 +371,17 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 		return nil, "", fmt.Errorf("error creating HTTP request: %w", err)
 	}
 
-	// Set headers if needed
+	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-
-	// Add authorization header if available
+	
+	// Add authorization header
 	authToken := os.Getenv("VOLUMES_API_TOKEN")
-	if authToken != "" {
-		req.Header.Set("Authorization", "Bearer "+authToken)
+	if authToken == "" {
+		// If not set in environment, use a default or return an error
+		return nil, "", fmt.Errorf("required environment variable VOLUMES_API_TOKEN not set")
 	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	klog.V(5).Infof("Added Authorization header with Bearer token")
 
 	// Make the HTTP request
 	resp, err := client.Do(req)

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -197,8 +197,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		return nil, status.Error(codes.InvalidArgument, "[ControllerPublishVolume] Volume capability must be provided")
 	}
 
-	//_, err := cs.Cloud.GetVolume(volumeID)
-	_, err := fetchVolumeByIDHTTP(volumeID)
+	_, err := cs.Cloud.GetVolume(volumeID)
 	if err != nil {
 		if cpoerrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] Volume %s not found", volumeID)
@@ -453,7 +452,7 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 		CreatedAt          string             `json:"created_at"`
 		Bootable           string             `json:"bootable"`
 		Encrypted          bool               `json:"encrypted"`
-		Multiattach        string             `json:"multiattach"`
+		Multiattach        bool               `json:"multiattach"`
 		Attachments        []CustomAttachment `json:"attachments"`
 	}
 
@@ -477,7 +476,7 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 	// Convert CustomVolume to volumes.Volume
 	for _, cv := range volumesResponse.Volumes {
 		// Convert string fields to appropriate types
-		multiattach := cv.Multiattach == "true"
+		multiattach := cv.Multiattach == false
 
 		// Convert attachments
 		attachments := make([]volumes.Attachment, 0, len(cv.Attachments))
@@ -523,7 +522,6 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 }
 
 func fetchVolumeByIDHTTP(volumeID string) (*volumes.Volume, error) {
-	fmt.Printf("fetchVolumeByIDHTTP....")
 	// Generate a unique request ID
 	requestID := generateRequestID()
 
@@ -634,7 +632,7 @@ func fetchVolumeByIDHTTP(volumeID string) (*volumes.Volume, error) {
 		CreatedAt          string             `json:"created_at"`
 		Bootable           string             `json:"bootable"`
 		Encrypted          bool               `json:"encrypted"`
-		Multiattach        string             `json:"multiattach"`
+		Multiattach        bool               `json:"multiattach"`
 		Attachments        []CustomAttachment `json:"attachments"`
 	}
 
@@ -651,7 +649,7 @@ func fetchVolumeByIDHTTP(volumeID string) (*volumes.Volume, error) {
 	cv := volumeResponse.Volume
 
 	// Convert string fields to appropriate types
-	multiattach := cv.Multiattach == "true"
+	multiattach := cv.Multiattach == false
 
 	// Convert attachments
 	attachments := make([]volumes.Attachment, 0, len(cv.Attachments))

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -18,6 +18,8 @@ package cinder
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,7 +36,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
 	"k8s.io/cloud-provider-openstack/pkg/util"
 	cpoerrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
@@ -329,18 +330,38 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	}, nil
 }
 
+func generateRequestID() string {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		// If we fail to generate random bytes, use timestamp as fallback
+		return fmt.Sprintf("req-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(bytes)
+}
+
 func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, string, error) {
 	volumeList := make([]volumes.Volume, 0)
+
+	// Generate a unique request ID
+	requestID := generateRequestID()
 
 	// Get configuration from environment variables
 	baseURL := os.Getenv("VOLUMES_API_URL")
 	region := os.Getenv("VOLUMES_API_REGION")
+	clusterName := os.Getenv("CLUSTER_NAME")
 
 	if baseURL == "" || region == "" {
 		return nil, "", fmt.Errorf("required environment variables VOLUMES_API_URL and VOLUMES_API_REGION not set")
 	}
 
-	klog.V(4).Infof("Fetching volumes from baseURL: %s, region: %s", baseURL, region)
+	if clusterName == "" {
+		// Use a default cluster name if not provided
+		clusterName = "unknown-cluster"
+		klog.V(4).Infof("CLUSTER_NAME environment variable not set, using default: %s", clusterName)
+	}
+
+	klog.V(4).Infof("Fetching volumes from baseURL: %s, region: %s, requestID: %s, cluster: %s",
+		baseURL, region, requestID, clusterName)
 
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -373,7 +394,9 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	
+	req.Header.Set("X-Request-ID", requestID)
+	req.Header.Set("X-Cluster-Name", clusterName)
+
 	// Add authorization header
 	authToken := os.Getenv("VOLUMES_API_TOKEN")
 	if authToken == "" {
@@ -381,7 +404,7 @@ func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, stri
 		return nil, "", fmt.Errorf("required environment variable VOLUMES_API_TOKEN not set")
 	}
 	req.Header.Set("Authorization", "Bearer "+authToken)
-	klog.V(5).Infof("Added Authorization header with Bearer token")
+	klog.V(5).Infof("Added Authorization header with Bearer token and request tracking headers")
 
 	// Make the HTTP request
 	resp, err := client.Do(req)

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -17,14 +17,20 @@ limitations under the License.
 package cinder
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
 	"strconv"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -280,21 +286,21 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 }
 
 func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	klog.V(4).Infof("ListVolumes: called with %+#v request", req)
+	klog.V(4).Infof("ListVolumesHTTP: called with %+#v request", req)
 
 	if req.MaxEntries < 0 {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf(
-			"[ListVolumes] Invalid max entries request %v, must not be negative ", req.MaxEntries))
+			"[ListVolumesHTTP] Invalid max entries request %v, must not be negative ", req.MaxEntries))
 	}
 	maxEntries := int(req.MaxEntries)
 
-	vlist, nextPageToken, err := cs.Cloud.ListVolumes(maxEntries, req.StartingToken)
+	vlist, nextPageToken, err := fetchVolumesHTTP(maxEntries, req.StartingToken)
 	if err != nil {
-		klog.Errorf("Failed to ListVolumes: %v", err)
+		klog.Errorf("Failed to ListVolumesHTTP: %v", err)
 		if cpoerrors.IsInvalidError(err) {
-			return nil, status.Errorf(codes.Aborted, "[ListVolumes] Invalid request: %v", err)
+			return nil, status.Errorf(codes.Aborted, "[ListVolumesHTTP] Invalid request: %v", err)
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("ListVolumes failed with error %v", err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("ListVolumesHTTP failed with error %v", err))
 	}
 
 	ventries := make([]*csi.ListVolumesResponse_Entry, 0, len(vlist))
@@ -316,11 +322,176 @@ func (cs *controllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 		ventries = append(ventries, &ventry)
 	}
 
-	klog.V(4).Infof("ListVolumes: completed with %d entries and %q next token", len(ventries), nextPageToken)
+	klog.V(4).Infof("ListVolumesHTTP: completed with %d entries and %q next token", len(ventries), nextPageToken)
 	return &csi.ListVolumesResponse{
 		Entries:   ventries,
 		NextToken: nextPageToken,
 	}, nil
+}
+
+func fetchVolumesHTTP(maxEntries int, nextMarker string) ([]volumes.Volume, string, error) {
+	volumeList := make([]volumes.Volume, 0)
+
+	// Get configuration from environment variables
+	baseURL := os.Getenv("VOLUMES_API_URL")
+	region := os.Getenv("VOLUMES_API_REGION")
+
+	if baseURL == "" || region == "" {
+		return nil, "", fmt.Errorf("required environment variables VOLUMES_API_URL and VOLUMES_API_REGION not set")
+	}
+
+	klog.V(4).Infof("Fetching volumes from baseURL: %s, region: %s", baseURL, region)
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("error parsing base URL: %w", err)
+	}
+
+	// Add the query parameters
+	query := u.Query()
+	query.Set("region", region)
+	if maxEntries > 0 {
+		query.Set("limit", strconv.Itoa(maxEntries))
+	}
+	if nextMarker != "" {
+		query.Set("marker", nextMarker)
+	}
+	u.RawQuery = query.Encode()
+
+	klog.V(5).Infof("Fetching volumes from URL: %s", u.String())
+
+	// Create a new HTTP client with timeout
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	// Create a new request
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating HTTP request: %w", err)
+	}
+
+	// Set headers if needed
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add authorization header if available
+	authToken := os.Getenv("VOLUMES_API_TOKEN")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	// Make the HTTP request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("error making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", fmt.Errorf("error reading error response body: %w, status code: %d", err, resp.StatusCode)
+		}
+		bodyString := string(bodyBytes)
+		return nil, "", fmt.Errorf("server returned error: %s, status code: %d, response body: %s", resp.Status, resp.StatusCode, bodyString)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("error reading response body: %w", err)
+	}
+
+	// Define a custom volume struct to handle string fields that need conversion
+	type CustomAttachment struct {
+		ServerID     string `json:"server_id"`
+		AttachmentID string `json:"attachment_id"`
+		HostName     string `json:"host_name"`
+		VolumeID     string `json:"volume_id"`
+		Device       string `json:"device"`
+		ID           string `json:"id"`
+	}
+
+	type CustomVolume struct {
+		ID                 string             `json:"id"`
+		DisplayName        string             `json:"display_name"`
+		Status             string             `json:"status"`
+		Size               int                `json:"size"`
+		Metadata           map[string]string  `json:"metadata"`
+		AvailabilityZone   string             `json:"availability_zone"`
+		DisplayDescription string             `json:"display_description"`
+		VolumeType         string             `json:"volume_type"`
+		CreatedAt          string             `json:"created_at"`
+		Bootable           string             `json:"bootable"`
+		Encrypted          bool               `json:"encrypted"`
+		Multiattach        string             `json:"multiattach"`
+		Attachments        []CustomAttachment `json:"attachments"`
+	}
+
+	// Unmarshal the JSON response
+	var volumesResponse struct {
+		Volumes     []CustomVolume `json:"volumes"`
+		TotalCount  int            `json:"total_count"`
+		HasMoreData bool           `json:"has_more_data"`
+	}
+
+	err = json.Unmarshal(body, &volumesResponse)
+	if err != nil {
+		return nil, "", fmt.Errorf("error unmarshalling JSON: %w, body: %s", err, string(body))
+	}
+
+	// Check if we have volumes
+	if len(volumesResponse.Volumes) == 0 {
+		return volumeList, "", nil
+	}
+
+	// Convert CustomVolume to volumes.Volume
+	for _, cv := range volumesResponse.Volumes {
+		// Convert string fields to appropriate types
+		multiattach := cv.Multiattach == "true"
+
+		// Convert attachments
+		attachments := make([]volumes.Attachment, 0, len(cv.Attachments))
+		for _, ca := range cv.Attachments {
+			attachments = append(attachments, volumes.Attachment{
+				ServerID:     ca.ServerID,
+				AttachmentID: ca.AttachmentID,
+				HostName:     ca.HostName,
+				VolumeID:     ca.VolumeID,
+				Device:       ca.Device,
+				ID:           ca.ID,
+			})
+		}
+
+		// Create a volumes.Volume object
+		vol := volumes.Volume{
+			ID:               cv.ID,
+			Name:             cv.DisplayName,
+			Status:           cv.Status,
+			Size:             cv.Size,
+			AvailabilityZone: cv.AvailabilityZone,
+			Description:      cv.DisplayDescription,
+			VolumeType:       cv.VolumeType,
+			Metadata:         cv.Metadata,
+			Bootable:         cv.Bootable,
+			Encrypted:        cv.Encrypted,
+			Multiattach:      multiattach,
+			Attachments:      attachments,
+		}
+
+		volumeList = append(volumeList, vol)
+	}
+
+	// Set the next marker from the last volume ID if has more data
+	var nextToken string
+	if volumesResponse.HasMoreData && len(volumeList) > 0 {
+		nextToken = volumeList[len(volumeList)-1].ID
+	}
+
+	klog.V(4).Infof("Fetched %d volumes, next token: %s, has more data: %v",
+		len(volumeList), nextToken, volumesResponse.HasMoreData)
+	return volumeList, nextToken, nil
 }
 
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
