### PR TITLE
updated client to add required request headers

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -275,6 +275,21 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		req.Header.Set("X-Region", t.Region)
 	}
 
+	// Extract volumeID from URL path and add as header only for operations that have a volumeID
+	// Skip for POST requests (like volume creation) where volumeID doesn't exist yet
+	if req.Method != "POST" {
+		pathParts := strings.Split(req.URL.Path, "/")
+		for i, part := range pathParts {
+			if part == "volumes" && i+1 < len(pathParts) {
+				volumeID := pathParts[i+1]
+				if volumeID != "" {
+					req.Header.Set("X-Volume-ID", volumeID)
+				}
+				break
+			}
+		}
+	}
+
 	// Log request
 	var reqBody []byte
 	var err error

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -259,8 +259,16 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	reqID := uuid.New().String()
 	req.Header.Set("X-Request-ID", reqID)
 
-	req.Header.Set("X-Cluster", os.Getenv("CLUSTER_NAME"))
-	req.Header.Set("Authorization", "Bearer "+os.Getenv("VOLUMES_API_TOKEN"))
+	token := os.Getenv("API_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("API token not set")
+	}
+	clusterName := os.Getenv("CLUSTER_NAME")
+	if clusterName == "" {
+		return nil, fmt.Errorf("CLUSTER_NAME not set")
+	}
+	req.Header.Set("X-Cluster", clusterName)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("X-Request-ID", reqID)
 	// Add region as header if not already present
 	if t.Region != "" && req.Header.Get("X-Region") == "" {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,18 +17,21 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
-	"github.com/gophercloud/utils/client"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"k8s.io/apimachinery/pkg/util/net"
@@ -243,6 +246,66 @@ func ReadClouds(authOpts *AuthOpts) error {
 	return nil
 }
 
+// LoggingTransport is a custom transport that logs requests and responses
+type LoggingTransport struct {
+	Transport http.RoundTripper
+	Region    string
+	Cluster   string
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add X-Request-ID header
+	reqID := uuid.New().String()
+	req.Header.Set("X-Request-ID", reqID)
+
+	req.Header.Set("X-Cluster", os.Getenv("CLUSTER_NAME"))
+	req.Header.Set("Authorization", "Bearer "+os.Getenv("VOLUMES_API_TOKEN"))
+	req.Header.Set("X-Request-ID", reqID)
+	// Add region as header if not already present
+	if t.Region != "" && req.Header.Get("X-Region") == "" {
+		req.Header.Set("X-Region", t.Region)
+	}
+
+	// Log request
+	var reqBody []byte
+	var err error
+	if req.Body != nil {
+		reqBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			klog.Errorf("Failed to read request body: %v", err)
+			return nil, err
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+	}
+
+	klog.Infof("Request [%s] %s %s\nHeaders: %v\nBody: %s",
+		reqID, req.Method, req.URL, req.Header, string(reqBody))
+
+	// Make the request
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		klog.Errorf("Request [%s] failed: %v", reqID, err)
+		return nil, err
+	}
+
+	// Log response
+	var respBody []byte
+	if resp.Body != nil {
+		respBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			klog.Errorf("Failed to read response body: %v", err)
+			return nil, err
+		}
+		resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+	}
+
+	klog.Infof("Response [%s] %s\nStatus: %s\nHeaders: %v\nBody: %s",
+		reqID, req.URL, resp.Status, resp.Header, string(respBody))
+
+	return resp, nil
+}
+
 // NewOpenStackClient creates a new instance of the openstack client
 func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...string) (*gophercloud.ProviderClient, error) {
 	provider, err := openstack.NewClient(cfg.AuthURL)
@@ -289,13 +352,13 @@ func NewOpenStackClient(cfg *AuthOpts, userAgent string, extraUserAgent ...strin
 		config.Certificates = []tls.Certificate{cert}
 	}
 
-	provider.HTTPClient.Transport = net.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
+	// Create base transport
+	baseTransport := net.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
 
-	if klog.V(6).Enabled() {
-		provider.HTTPClient.Transport = &client.RoundTripper{
-			Rt:     provider.HTTPClient.Transport,
-			Logger: &Logger{},
-		}
+	// Wrap with logging transport
+	provider.HTTPClient.Transport = &LoggingTransport{
+		Transport: baseTransport,
+		Region:    cfg.Region,
 	}
 
 	if cfg.TrustID != "" {

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -41,13 +41,16 @@ const (
 	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
-	diskAttachInitDelay      = 30 * time.Second // increased from 10s to 30s
-	diskAttachFactor         = 1.5              // increased from 1.2 to 1.5
-	diskAttachSteps          = 15
-	diskDetachInitDelay      = 30 * time.Second // increased from 10s to 30s
-	diskDetachFactor         = 1.5              // increased from 1.2 to 1.5
-	diskDetachSteps          = 15
-	volumeDescription        = "Created by OpenStack Cinder CSI driver"
+
+	diskAttachInitDelay = 30 * time.Second // increased from 10s to 30s
+	diskAttachFactor    = 1.5              // increased from 1.2 to 1.5
+	diskAttachSteps     = 15
+	//This means retry will be executed like - 30s → 45s → 67.5s → 101.25s → 151.88s → 227.81s → 341.72s → 512.58s → 768.87s → 1153.31s → 1729.96s → 2594.94s → 3892.41s → 5838.62s → 8757.93s
+
+	diskDetachInitDelay = 30 * time.Second // increased from 10s to 30s
+	diskDetachFactor    = 1.5              // increased from 1.2 to 1.5
+	diskDetachSteps     = 15
+	volumeDescription   = "Created by OpenStack Cinder CSI driver"
 )
 
 var volumeErrorStates = [...]string{"error", "error_extending", "error_deleting"}
@@ -276,30 +279,39 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 		// Check volume attachment status using existing function
 		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
 		if err != nil {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s attachment status for instance %s: %v", currentTime, retryCount, volumeID, instanceID, err)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s attachment status for instance %s: %v",
+				currentTime, retryCount, volumeID, instanceID, err)
 			klog.Errorf(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 		if !volumeAttached {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet attached to instance %s", currentTime, retryCount, volumeID, instanceID)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet attached to instance %s",
+				currentTime, retryCount, volumeID, instanceID)
 			klog.V(2).Infof(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 
 		// Check Nova instance attachment status
 		instanceAttached, err := os.isVolumeAttachedToInstance(instanceID, volumeID)
 		if err != nil {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s attachment status for volume %s: %v", currentTime, retryCount, instanceID, volumeID, err)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s attachment status for volume %s: %v",
+				currentTime, retryCount, instanceID, volumeID, err)
 			klog.Errorf(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 		if !instanceAttached {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet visible in instance %s attached volumes", currentTime, retryCount, volumeID, instanceID)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet visible in instance %s attached volumes",
+				currentTime, retryCount, volumeID, instanceID)
 			klog.V(2).Infof(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 
-		klog.V(2).Infof("[%s] Volume %s is successfully attached to instance %s after %d retries", currentTime, volumeID, instanceID, retryCount)
+		klog.V(2).Infof("[%s] Volume %s is successfully attached to instance %s after %d retries",
+			currentTime, volumeID, instanceID, retryCount)
 		return true, nil
 	})
 
@@ -402,6 +414,7 @@ func (os *OpenStack) isVolumeDetachedFromInstance(instanceID, volumeID string) (
 }
 
 // WaitDiskDetached waits for volume to be detached from the instance
+
 func (os *OpenStack) WaitDiskDetached(instanceID string, volumeID string) error {
 	backoff := wait.Backoff{
 		Duration: diskDetachInitDelay,
@@ -417,36 +430,46 @@ func (os *OpenStack) WaitDiskDetached(instanceID string, volumeID string) error 
 		// Check volume detachment status using existing function
 		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
 		if err != nil {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s detachment status for instance %s: %v", currentTime, retryCount, volumeID, instanceID, err)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s detachment status for instance %s: %v",
+				currentTime, retryCount, volumeID, instanceID, err)
 			klog.Errorf(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 		if volumeAttached {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still attached to instance %s", currentTime, retryCount, volumeID, instanceID)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still attached to instance %s",
+				currentTime, retryCount, volumeID, instanceID)
 			klog.V(2).Infof(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 
 		// Check Nova instance detachment status
 		instanceDetached, err := os.isVolumeDetachedFromInstance(instanceID, volumeID)
 		if err != nil {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s detachment status for volume %s: %v", currentTime, retryCount, instanceID, volumeID, err)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s detachment status for volume %s: %v",
+				currentTime, retryCount, instanceID, volumeID, err)
 			klog.Errorf(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 		if !instanceDetached {
-			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still visible in instance %s attached volumes", currentTime, retryCount, volumeID, instanceID)
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still visible in instance %s attached volumes",
+				currentTime, retryCount, volumeID, instanceID)
 			klog.V(2).Infof(lastErr.Error())
+			// Return error to expose it as an event
 			return false, lastErr
 		}
 
-		klog.V(2).Infof("[%s] Volume %s is successfully detached from instance %s after %d retries", currentTime, volumeID, instanceID, retryCount)
+		klog.V(2).Infof("[%s] Volume %s is successfully detached from instance %s after %d retries",
+			currentTime, volumeID, instanceID, retryCount)
 		return true, nil
 	})
 
 	if wait.Interrupted(err) {
 		currentTime := time.Now().Format(time.RFC3339)
-		err = fmt.Errorf("[%s] Volume %q failed to detach within the alloted time after %d retries. Last error: %v", currentTime, volumeID, retryCount, lastErr)
+		err = fmt.Errorf("[%s] Volume %q failed to detach within the alloted time after %d retries. Last error: %v",
+			currentTime, volumeID, retryCount, lastErr)
 		klog.Errorf("Volume detachment timeout: %v", err)
 	}
 

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -41,11 +41,11 @@ const (
 	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
-	diskAttachInitDelay      = 6 * time.Second
-	diskAttachFactor         = 1.2
+	diskAttachInitDelay      = 30 * time.Second // increased from 10s to 30s
+	diskAttachFactor         = 1.5              // increased from 1.2 to 1.5
 	diskAttachSteps          = 15
-	diskDetachInitDelay      = 6 * time.Second
-	diskDetachFactor         = 1.2
+	diskDetachInitDelay      = 30 * time.Second // increased from 10s to 30s
+	diskDetachFactor         = 1.5              // increased from 1.2 to 1.5
 	diskDetachSteps          = 15
 	volumeDescription        = "Created by OpenStack Cinder CSI driver"
 )
@@ -268,35 +268,45 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 		Steps:    diskAttachSteps,
 	}
 
+	var lastErr error
+	var retryCount int
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		retryCount++
+		currentTime := time.Now().Format(time.RFC3339)
 		// Check volume attachment status using existing function
 		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
 		if err != nil {
-			klog.Errorf("Failed to check volume %s attachment status for instance %s: %v", volumeID, instanceID, err)
-			return false, err
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s attachment status for instance %s: %v", currentTime, retryCount, volumeID, instanceID, err)
+			klog.Errorf(lastErr.Error())
+			return false, lastErr
 		}
 		if !volumeAttached {
-			klog.V(2).Infof("Volume %s is not yet attached to instance %s", volumeID, instanceID)
-			return false, nil
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet attached to instance %s", currentTime, retryCount, volumeID, instanceID)
+			klog.V(2).Infof(lastErr.Error())
+			return false, lastErr
 		}
 
 		// Check Nova instance attachment status
 		instanceAttached, err := os.isVolumeAttachedToInstance(instanceID, volumeID)
 		if err != nil {
-			klog.Errorf("Failed to check instance %s attachment status for volume %s: %v", instanceID, volumeID, err)
-			return false, err
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s attachment status for volume %s: %v", currentTime, retryCount, instanceID, volumeID, err)
+			klog.Errorf(lastErr.Error())
+			return false, lastErr
 		}
 		if !instanceAttached {
-			klog.V(2).Infof("Volume %s is not yet visible in instance %s attached volumes", volumeID, instanceID)
-			return false, nil
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is not yet visible in instance %s attached volumes", currentTime, retryCount, volumeID, instanceID)
+			klog.V(2).Infof(lastErr.Error())
+			return false, lastErr
 		}
 
-		klog.V(2).Infof("Volume %s is successfully attached to instance %s", volumeID, instanceID)
+		klog.V(2).Infof("[%s] Volume %s is successfully attached to instance %s after %d retries", currentTime, volumeID, instanceID, retryCount)
 		return true, nil
 	})
 
 	if wait.Interrupted(err) {
-		err = fmt.Errorf("Volume %q failed to be attached within the alloted time", volumeID)
+		currentTime := time.Now().Format(time.RFC3339)
+		err = fmt.Errorf("[%s] Volume %q failed to be attached within the alloted time after %d retries. Last error: %v",
+			currentTime, volumeID, retryCount, lastErr)
 		klog.Errorf("Volume attachment timeout: %v", err)
 	}
 
@@ -399,35 +409,44 @@ func (os *OpenStack) WaitDiskDetached(instanceID string, volumeID string) error 
 		Steps:    diskDetachSteps,
 	}
 
+	var lastErr error
+	var retryCount int
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		retryCount++
+		currentTime := time.Now().Format(time.RFC3339)
 		// Check volume detachment status using existing function
 		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
 		if err != nil {
-			klog.Errorf("Failed to check volume %s detachment status for instance %s: %v", volumeID, instanceID, err)
-			return false, err
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check volume %s detachment status for instance %s: %v", currentTime, retryCount, volumeID, instanceID, err)
+			klog.Errorf(lastErr.Error())
+			return false, lastErr
 		}
 		if volumeAttached {
-			klog.V(2).Infof("Volume %s is still attached to instance %s", volumeID, instanceID)
-			return false, nil
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still attached to instance %s", currentTime, retryCount, volumeID, instanceID)
+			klog.V(2).Infof(lastErr.Error())
+			return false, lastErr
 		}
 
 		// Check Nova instance detachment status
 		instanceDetached, err := os.isVolumeDetachedFromInstance(instanceID, volumeID)
 		if err != nil {
-			klog.Errorf("Failed to check instance %s detachment status for volume %s: %v", instanceID, volumeID, err)
-			return false, err
+			lastErr = fmt.Errorf("[%s] Attempt %d: Failed to check instance %s detachment status for volume %s: %v", currentTime, retryCount, instanceID, volumeID, err)
+			klog.Errorf(lastErr.Error())
+			return false, lastErr
 		}
 		if !instanceDetached {
-			klog.V(2).Infof("Volume %s is still visible in instance %s attached volumes", volumeID, instanceID)
-			return false, nil
+			lastErr = fmt.Errorf("[%s] Attempt %d: Volume %s is still visible in instance %s attached volumes", currentTime, retryCount, volumeID, instanceID)
+			klog.V(2).Infof(lastErr.Error())
+			return false, lastErr
 		}
 
-		klog.V(2).Infof("Volume %s is successfully detached from instance %s", volumeID, instanceID)
+		klog.V(2).Infof("[%s] Volume %s is successfully detached from instance %s after %d retries", currentTime, volumeID, instanceID, retryCount)
 		return true, nil
 	})
 
 	if wait.Interrupted(err) {
-		err = fmt.Errorf("Volume %q failed to detach within the alloted time", volumeID)
+		currentTime := time.Now().Format(time.RFC3339)
+		err = fmt.Errorf("[%s] Volume %q failed to detach within the alloted time after %d retries. Last error: %v", currentTime, volumeID, retryCount, lastErr)
 		klog.Errorf("Volume detachment timeout: %v", err)
 	}
 

--- a/pkg/csi/cinder/openstack/openstack_volumes.go
+++ b/pkg/csi/cinder/openstack/openstack_volumes.go
@@ -223,7 +223,44 @@ func (os *OpenStack) AttachVolume(instanceID, volumeID string) (string, error) {
 	return volume.ID, nil
 }
 
-// WaitDiskAttached waits for attched
+// GetVolumeAttachments retrieves the list of volume attachments for a server
+func (os *OpenStack) GetVolumeAttachments(instanceID string) ([]volumeattach.VolumeAttachment, error) {
+	mc := metrics.NewMetricContext("volume_attachment", "list")
+	pages, err := volumeattach.List(os.compute, instanceID).AllPages()
+	if mc.ObserveRequest(err) != nil {
+		return nil, fmt.Errorf("failed to get volume attachments for instance %s: %v", instanceID, err)
+	}
+	attachments, err := volumeattach.ExtractVolumeAttachments(pages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract volume attachments for instance %s: %v", instanceID, err)
+	}
+	return attachments, nil
+}
+
+// isVolumeAttachedToInstance checks if a volume is attached to a Nova instance
+func (os *OpenStack) isVolumeAttachedToInstance(instanceID, volumeID string) (bool, error) {
+	attachments, err := os.GetVolumeAttachments(instanceID)
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			klog.Warningf("Instance %s not found while checking volume %s attachment", instanceID, volumeID)
+			return false, fmt.Errorf("instance %s not found", instanceID)
+		}
+		klog.Errorf("Failed to get volume attachments for instance %s: %v", instanceID, err)
+		return false, err
+	}
+
+	for _, att := range attachments {
+		if att.VolumeID == volumeID {
+			klog.V(2).Infof("Volume %s is found in instance %s attached volumes list", volumeID, instanceID)
+			return true, nil
+		}
+	}
+
+	klog.V(2).Infof("Volume %s is not found in instance %s attached volumes list", volumeID, instanceID)
+	return false, nil
+}
+
+// WaitDiskAttached waits for volume to be attached to the instance
 func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error {
 	backoff := wait.Backoff{
 		Duration: diskAttachInitDelay,
@@ -232,17 +269,35 @@ func (os *OpenStack) WaitDiskAttached(instanceID string, volumeID string) error 
 	}
 
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		attached, err := os.diskIsAttached(instanceID, volumeID)
-		if err != nil && !cpoerrors.IsNotFound(err) {
-			// if this is a race condition indicate the volume is deleted
-			// during sleep phase, ignore the error and return attach=false
+		// Check volume attachment status using existing function
+		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
+		if err != nil {
+			klog.Errorf("Failed to check volume %s attachment status for instance %s: %v", volumeID, instanceID, err)
 			return false, err
 		}
-		return attached, nil
+		if !volumeAttached {
+			klog.V(2).Infof("Volume %s is not yet attached to instance %s", volumeID, instanceID)
+			return false, nil
+		}
+
+		// Check Nova instance attachment status
+		instanceAttached, err := os.isVolumeAttachedToInstance(instanceID, volumeID)
+		if err != nil {
+			klog.Errorf("Failed to check instance %s attachment status for volume %s: %v", instanceID, volumeID, err)
+			return false, err
+		}
+		if !instanceAttached {
+			klog.V(2).Infof("Volume %s is not yet visible in instance %s attached volumes", volumeID, instanceID)
+			return false, nil
+		}
+
+		klog.V(2).Infof("Volume %s is successfully attached to instance %s", volumeID, instanceID)
+		return true, nil
 	})
 
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("Volume %q failed to be attached within the alloted time", volumeID)
+		klog.Errorf("Volume attachment timeout: %v", err)
 	}
 
 	return err
@@ -313,7 +368,30 @@ func (os *OpenStack) DetachVolume(instanceID, volumeID string) error {
 	return nil
 }
 
-// WaitDiskDetached waits for detached
+// isVolumeDetachedFromInstance checks if a volume is detached from a Nova instance
+func (os *OpenStack) isVolumeDetachedFromInstance(instanceID, volumeID string) (bool, error) {
+	attachments, err := os.GetVolumeAttachments(instanceID)
+	if err != nil {
+		if cpoerrors.IsNotFound(err) {
+			klog.Warningf("Instance %s not found while checking volume %s detachment", instanceID, volumeID)
+			return false, fmt.Errorf("instance %s not found", instanceID)
+		}
+		klog.Errorf("Failed to get volume attachments for instance %s: %v", instanceID, err)
+		return false, err
+	}
+
+	for _, att := range attachments {
+		if att.VolumeID == volumeID {
+			klog.V(2).Infof("Volume %s is still found in instance %s attached volumes list", volumeID, instanceID)
+			return false, nil
+		}
+	}
+
+	klog.V(2).Infof("Volume %s is not found in instance %s attached volumes list", volumeID, instanceID)
+	return true, nil
+}
+
+// WaitDiskDetached waits for volume to be detached from the instance
 func (os *OpenStack) WaitDiskDetached(instanceID string, volumeID string) error {
 	backoff := wait.Backoff{
 		Duration: diskDetachInitDelay,
@@ -322,15 +400,35 @@ func (os *OpenStack) WaitDiskDetached(instanceID string, volumeID string) error 
 	}
 
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		attached, err := os.diskIsAttached(instanceID, volumeID)
+		// Check volume detachment status using existing function
+		volumeAttached, err := os.diskIsAttached(instanceID, volumeID)
 		if err != nil {
+			klog.Errorf("Failed to check volume %s detachment status for instance %s: %v", volumeID, instanceID, err)
 			return false, err
 		}
-		return !attached, nil
+		if volumeAttached {
+			klog.V(2).Infof("Volume %s is still attached to instance %s", volumeID, instanceID)
+			return false, nil
+		}
+
+		// Check Nova instance detachment status
+		instanceDetached, err := os.isVolumeDetachedFromInstance(instanceID, volumeID)
+		if err != nil {
+			klog.Errorf("Failed to check instance %s detachment status for volume %s: %v", instanceID, volumeID, err)
+			return false, err
+		}
+		if !instanceDetached {
+			klog.V(2).Infof("Volume %s is still visible in instance %s attached volumes", volumeID, instanceID)
+			return false, nil
+		}
+
+		klog.V(2).Infof("Volume %s is successfully detached from instance %s", volumeID, instanceID)
+		return true, nil
 	})
 
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("Volume %q failed to detach within the alloted time", volumeID)
+		klog.Errorf("Volume detachment timeout: %v", err)
 	}
 
 	return err


### PR DESCRIPTION
This PR has following changes:

## Functionality change: 

1. Updated the CSI Cinder client to add some headers like region, API_TOKEN, X-Cluster-Name, X-Request-ID while originating request to CSI Proxy.
2. Added an extra check using NOVA APIs to validate the volume attachment from server side as well. This will improve correctness of our CSI attach-detach process.

## Error Propagation
 
I am using _lastErr_ obj to keep accumulating the errors. The key benefits of using _lastErr_ are

1. Error Context Preservation:
2. When the timeout occurs, we know exactly what was the last state/error
3. The error message in pod events will be more informative
4. Better Debugging:
5. Users can see exactly why the volume attachment failed
6. Instead of just seeing "timeout", they see "Volume X is not yet attached to instance Y"

Sample Pod events after this change :

```bash

Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Warning  FailedScheduling        50s                default-scheduler        0/2 nodes are available: persistentvolumeclaim "nginx-pvc-116" not found. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling.
  Normal   Scheduled               48s                default-scheduler        Successfully assigned default/nginx-deployment-116-7cb686bc47-hhwm5 to pooler-1748611246427
  Warning  FailedAttachVolume      44s (x2 over 45s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-0326542c-9894-4649-b687-30bc10b71763" : rpc error: code = Internal desc = [ControllerPublishVolume] failed to attach volume: [2025-06-03T07:07:25Z] Attempt 1: Volume bdebb5a5-4de8-4362-b3e0-2e38fce31315 is not yet attached to instance 7f2976a5-7e44-41dc-aad6-653ab710846b
  Warning  FailedAttachVolume      27s (x4 over 43s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-0326542c-9894-4649-b687-30bc10b71763" : rpc error: code = Internal desc = [ControllerPublishVolume] Attach Volume failed with error failed to attach bdebb5a5-4de8-4362-b3e0-2e38fce31315 volume to 7f2976a5-7e44-41dc-aad6-653ab710846b compute: Bad request with: [POST https://csi-proxy-staging4.platform9.horse/iad.servers/v2/1340444/servers/7f2976a5-7e44-41dc-aad6-653ab710846b/os-volume_attachments], error message: {"badRequest": {"message": "Invalid volume: volume 'bdebb5a5-4de8-4362-b3e0-2e38fce31315' status must be 'available'. Currently in 'attaching'", "code": 400}}
  Normal   SuccessfulAttachVolume  10s                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-0326542c-9894-4649-b687-30bc10b71763"
  Normal   Pulling                 6s                 kubelet                  Pulling image "nginx:latest"
  Normal   Pulled                  5s                 kubelet                  Successfully pulled image "nginx:latest" in 457ms (457ms including waiting). Image size: 72402122 bytes.
  Normal   Created                 5s                 kubelet                  Created container nginx
  Normal   Started                 5s                 kubelet                  Started container nginx

```




## Changes in Retry mechanism

I've made the following changes to give more time between retries:
1. Increased diskAttachInitDelay from 10s to 30s
- This gives more time for the initial attach operation to complete
- Helps avoid the "volume in attaching state" error

2. Increased diskAttachFactor from 1.2 to 1.5
- Makes the backoff more aggressive
- Each retry will wait 50% longer than the previous one

3.  Applied the same changes to detachment parameters for consistency
With these new values, the retry pattern will be:
- 1st retry: 30 seconds
- 2nd retry: 45 seconds (30 * 1.5)
- 3rd retry: 67.5 seconds (45 * 1.5)
- And so on...

This should:

1. Give more time for the volume to transition from 'attaching' to 'available' state
2. Reduce the likelihood of hitting the "volume in attaching state" error
3. Still maintain a reasonable total timeout period
4. Be more respectful to the OpenStack API rate limits